### PR TITLE
Fix logic for cutoff

### DIFF
--- a/odcm.py
+++ b/odcm.py
@@ -325,10 +325,12 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
         logger.info("Preprocessing %s", input_features)
 
         # Create a copy of the input features in the output workspace
+        logger.debug("Copying %s", input_features)
         desc_input_features = arcpy.Describe(input_features)
         input_path = desc_input_features.catalogPath
         output_features = arcpy.CreateUniqueName(os.path.basename(input_path), output_workspace)
-        arcpy.management.Copy(input_features, output_features)
+        result = arcpy.management.Copy(input_features, output_features)
+        logger.debug(result.getMessages().split("\n")[-1])
         desc_output_features = arcpy.Describe(output_features)
 
         # Add a unique ID field so we don't lose OID info when we sort and can use these later in joins.
@@ -337,7 +339,8 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
         logger.debug("Adding unique ID field for %s", input_features)
         if unique_id_field_name not in [f.name for f in desc_output_features.fields]:
             arcpy.management.AddField(output_features, unique_id_field_name, "LONG")
-        arcpy.management.CalculateField(output_features, unique_id_field_name, f"!{desc_output_features.oidFieldName}!")
+        result = arcpy.management.CalculateField(output_features, unique_id_field_name, f"!{desc_output_features.oidFieldName}!")
+        logger.debug(result.getMessages().split("\n")[-1])
 
         # Spatially sort input features
         try:

--- a/odcm.py
+++ b/odcm.py
@@ -273,6 +273,11 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
             The search criteria for the netrwork dataset.
 
         """
+        if arcpy.GetInstallInfo()["Version"] >= "2.6":
+            # In ArcGIS Pro 2.6, the Calculate Locations tool was given a good default value for this parameter.
+            # Because the code below can be slow for some networks, in version 2.6 or later, skip it and rely on
+            # the tool defaults.
+            return ""
         # Determine if a network source defines subtypes. The search criteria needs to be specified for each subtype
         # using the following pattern ["SourceName : subtype description", "SHAPE"]
         tmp_search_criteria = []


### PR DESCRIPTION
This logic was all messed up, and there were codepaths that led to nothing being selected, and that messed up load() later.

To fix it, first select the correct destinations for the chunk based on OIDs.  Then, if the user has designated a cutoff, perform a further selection to select only the OIDs within the cutoff.  If at this point nothing is selected, then there are no valid destinations for this chunk. Before calling load() make sure there is a valid destination layer.  If there isn't, just end the chunk and move on.

Also a few other minor improvements.