### PR TITLE
Add message to script tool to tell user the location of the progress log so they can see status messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+odcm_outputs.txt

--- a/odcm_gptool.py
+++ b/odcm_gptool.py
@@ -1,6 +1,6 @@
 """Execution code for Solve Origin Destination Cost Matrix tool."""
 ################################################################################
-'''Copyright 2020 Esri
+'''Copyright 2021 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
@@ -83,13 +83,17 @@ def solve_odcm():
     output_msg_file = os.path.join(cwd, "odcm_outputs.txt")
     with open(output_msg_file, "w") as output_fp:
         try:
-            odcm_result = subprocess.run(odcm_inputs, stderr=subprocess.STDOUT, stdout=output_fp, check=True,
-                                         creationflags=create_no_window)
+            subprocess.run(
+                odcm_inputs,
+                stderr=subprocess.STDOUT,
+                stdout=output_fp,
+                check=True,
+                creationflags=create_no_window
+            )
         except subprocess.CalledProcessError as ex:
             arcpy.AddError(f"Call to ODCM command line tool failed. Check {output_msg_file} for additional details.")
             arcpy.AddError(f"{ex}")
             raise SystemExit(-1)
-        # arcpy.AddMessage(output_fp.readlines())
 
 
 if __name__ == "__main__":

--- a/odcm_gptool.py
+++ b/odcm_gptool.py
@@ -81,6 +81,8 @@ def solve_odcm():
     create_no_window = 0x08000000
     # Store any output messages (failure as well as success) from the command line tool in a log file
     output_msg_file = os.path.join(cwd, "odcm_outputs.txt")
+    arcpy.AddMessage("Calculating OD Cost Matrix...")
+    arcpy.AddMessage(f"Progress messages for this calculation are being written to {output_msg_file}.")
     with open(output_msg_file, "w") as output_fp:
         try:
             subprocess.run(


### PR DESCRIPTION
A user requested that the script tool display progress messages so he can estimate how much time the tool has remaining.  Because the tool spins up a subprocess and launches other subprocesses in parallel, it is not possible to print status messages to the original GP window. However, the messages do already get printed to a log file. We didn't have any messaging in the script tool to alert the users to the location of the log file, so I have added a message doing so. This way at least the user can copy the path to the log file, open it, and refresh it to see updates.  It's not a wonderful solution, but I think it's the best we can do given the tool's architecture.

I also cleaned up some spelling problems in various comments and updated some formatting.