### PR TITLE
Fix checking portal tool limits when limits are None

### DIFF
--- a/solve_large_odcm.py
+++ b/solve_large_odcm.py
@@ -242,17 +242,22 @@ class ODCostMatrixSolver():  # pylint: disable=too-many-instance-attributes, too
 
     def _update_max_inputs_for_service(self):
         """Check the user's specified max origins and destinations and reduce max to portal limits if required."""
-        lim_max_origins = int(self.service_limits["maximumOrigins"])
-        if lim_max_origins < self.max_origins:
-            self.max_origins = lim_max_origins
-            arcpy.AddMessage(
-                f"Max origins per chunk has been updated to {self.max_origins} to accommodate service limits.")
-        lim_max_destinations = int(self.service_limits["maximumDestinations"])
-        if lim_max_destinations < self.max_destinations:
-            self.max_destinations = lim_max_destinations
-            arcpy.AddMessage(
-                f"Max destinations per chunk has been updated to {self.max_destinations} to accommodate service limits."
-            )
+        lim_max_origins = self.service_limits["maximumOrigins"]
+        if lim_max_origins:
+            lim_max_origins = int(lim_max_origins)
+            if lim_max_origins < self.max_origins:
+                self.max_origins = lim_max_origins
+                arcpy.AddMessage(
+                    f"Max origins per chunk has been updated to {self.max_origins} to accommodate service limits.")
+        lim_max_destinations = self.service_limits["maximumDestinations"]
+        if lim_max_destinations:
+            lim_max_destinations = int(lim_max_destinations)
+            if lim_max_destinations < self.max_destinations:
+                self.max_destinations = lim_max_destinations
+                arcpy.AddMessage((
+                    f"Max destinations per chunk has been updated to {self.max_destinations} to accommodate service "
+                    "limits."
+                ))
 
     @staticmethod
     def _spatially_sort_input(input_features, tracked_oid_name):

--- a/unittests/test_solve_large_odcm.py
+++ b/unittests/test_solve_large_odcm.py
@@ -121,12 +121,15 @@ class TestSolveLargeODCM(unittest.TestCase):
 
     def test_update_max_inputs_for_service(self):
         """Test the update_max_inputs_for_service function."""
+        max_origins = 1500
+        max_destinations = 700
+
         inputs = deepcopy(self.od_args)
         inputs["network_data_source"] = self.portal_nd
         inputs["travel_mode"] = self.portal_tm
         od_solver = solve_large_odcm.ODCostMatrixSolver(**inputs)
-        od_solver.max_origins = 1500
-        od_solver.max_destinations = 700
+        od_solver.max_origins = max_origins
+        od_solver.max_destinations = max_destinations
         tool_limits = {
             'forceHierarchyBeyondDistance': 50.0,
             'forceHierarchyBeyondDistanceUnits':
@@ -142,7 +145,27 @@ class TestSolveLargeODCM(unittest.TestCase):
         od_solver.service_limits = tool_limits
         od_solver._update_max_inputs_for_service()
         self.assertEqual(tool_limits["maximumOrigins"], od_solver.max_origins)
-        self.assertEqual(700, od_solver.max_destinations)
+        self.assertEqual(max_destinations, od_solver.max_destinations)
+
+        # Test when there are no limits
+        tool_limits = {
+            'forceHierarchyBeyondDistance': 50.0,
+            'forceHierarchyBeyondDistanceUnits':
+            'Miles',
+            'maximumDestinations': None,
+            'maximumFeaturesAffectedByLineBarriers': 500.0,
+            'maximumFeaturesAffectedByPointBarriers': 250.0,
+            'maximumFeaturesAffectedByPolygonBarriers': 2000.0,
+            'maximumGeodesicDistanceUnitsWhenWalking': 'Miles',
+            'maximumGeodesicDistanceWhenWalking': 27.0,
+            'maximumOrigins': None
+        }
+        od_solver.max_origins = max_origins
+        od_solver.max_destinations = max_destinations
+        od_solver.service_limits = tool_limits
+        od_solver._update_max_inputs_for_service()
+        self.assertEqual(max_origins, od_solver.max_origins)
+        self.assertEqual(max_destinations, od_solver.max_destinations)
 
     def test_spatially_sort_input(self):
         """Test the spatially_sort_input function."""


### PR DESCRIPTION
Tool was failing when the network data source is a portal that has no analysis limits for the OD Cost Matrix tool because the tool limit handling was expecting an integer.