### PR TITLE
Properly tear down logging for each parallel process

### DIFF
--- a/parallel_odcm.py
+++ b/parallel_odcm.py
@@ -673,6 +673,12 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
             file_handler.setFormatter(formatter)
             logger_obj.addHandler(file_handler)
 
+    def teardown_logger(self):
+        """Clean up and close the logger."""
+        for handler in self.logger.handlers:
+            handler.close()
+            self.logger.removeHandler(handler)
+
 
 def solve_od_cost_matrix(inputs, chunk):
     """Solve an OD Cost Matrix analysis for the given inputs for the given chunk of ObjectIDs.
@@ -692,6 +698,7 @@ def solve_od_cost_matrix(inputs, chunk):
         f"as job id {odcm.job_id}"
     ))
     odcm.solve(chunk[0], chunk[1])
+    odcm.teardown_logger()
     return odcm.job_result
 
 
@@ -820,9 +827,7 @@ class ParallelODCalculator:
             if odcm:
                 LOGGER.debug("Deleting temporary test OD Cost Matrix job folder...")
                 # Close logging
-                for handler in odcm.logger.handlers:
-                    handler.close()
-                    odcm.logger.removeHandler(handler)
+                odcm.teardown_logger()
                 # Delete output folder
                 shutil.rmtree(odcm.job_result["jobFolder"], ignore_errors=True)
                 del odcm

--- a/parallel_route_pairs.py
+++ b/parallel_route_pairs.py
@@ -428,6 +428,12 @@ class Route:  # pylint:disable = too-many-instance-attributes
             file_handler.setFormatter(formatter)
             logger_obj.addHandler(file_handler)
 
+    def teardown_logger(self):
+        """Clean up and close the logger."""
+        for handler in self.logger.handlers:
+            handler.close()
+            self.logger.removeHandler(handler)
+
 
 def solve_route(inputs, chunk):
     """Solve a Route analysis for the given inputs for the given chunk of ObjectIDs.
@@ -442,6 +448,7 @@ def solve_route(inputs, chunk):
     rt = Route(**inputs)
     rt.logger.info(f"Processing origins OID {chunk[0]} to {chunk[1]} as job id {rt.job_id}")
     rt.solve(chunk)
+    rt.teardown_logger()
     return rt.job_result
 
 
@@ -546,9 +553,7 @@ class ParallelRoutePairCalculator:
             if rt:
                 LOGGER.debug("Deleting temporary test Route job folder...")
                 # Close logging
-                for handler in rt.logger.handlers:
-                    handler.close()
-                    rt.logger.removeHandler(handler)
+                rt.teardown_logger()
                 # Delete output folder
                 shutil.rmtree(rt.job_result["jobFolder"], ignore_errors=True)
                 del rt


### PR DESCRIPTION
A user ran into an OSError "Too many open files", which I believe relates to the fact that I'm not properly closing the logs from each parallel process.