### PR TITLE
Update tools for ArcGIS Pro 3.1 release

### DIFF
--- a/parallel_odcm.py
+++ b/parallel_odcm.py
@@ -381,7 +381,10 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
         # For services solve, export Origins and Destinations and properly populate OriginOID and DestinationOID fields
         # in the output Lines. Services do not preserve the original input OIDs, instead resetting from 1, unlike solves
         # using a local network dataset, so this extra post-processing step is necessary.
-        if self.is_service:
+        ## TODO: Need to check service version?
+        # NOTE: In 3.0, this logic is still needed.  I believe this was a client-side fix in 3.1, so it shouldn't matter
+        # what version of portal is being used.  Need to test in 3.1 and 3.0.
+        if self.is_service and helpers.arcgis_version < "3.1":
             output_origins = os.path.join(od_workspace, "output_od_origins")
             self.logger.debug(f"Exporting OD cost matrix Origins output to {output_origins}...")
             self.solve_result.export(arcpy.nax.OriginDestinationCostMatrixOutputDataType.Origins, output_origins)
@@ -431,7 +434,9 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
         # For services solve, properly populate OriginOID and DestinationOID fields in the output Lines. Services do
         # not preserve the original input OIDs, instead resetting from 1, unlike solves using a local network dataset,
         # so this extra post-processing step is necessary.
-        if self.is_service:
+        ## TODO: Need to check service version
+        # NOTE: In 3.0, this logic is still needed.
+        if self.is_service and helpers.arcgis_version < "3.1":
             # Read the Lines output
             with self.solve_result.searchCursor(
                 arcpy.nax.OriginDestinationCostMatrixOutputDataType.Lines, self.output_fields

--- a/parallel_odcm.py
+++ b/parallel_odcm.py
@@ -378,12 +378,10 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
         self.solve_result.export(arcpy.nax.OriginDestinationCostMatrixOutputDataType.Lines, output_od_lines)
         self.job_result["outputLines"] = output_od_lines
 
-        # For services solve, export Origins and Destinations and properly populate OriginOID and DestinationOID fields
-        # in the output Lines. Services do not preserve the original input OIDs, instead resetting from 1, unlike solves
-        # using a local network dataset, so this extra post-processing step is necessary.
-        ## TODO: Need to check service version?
-        # NOTE: In 3.0, this logic is still needed.  I believe this was a client-side fix in 3.1, so it shouldn't matter
-        # what version of portal is being used.  Need to test in 3.1 and 3.0.
+        # For services solve in pre-3.0 versions of ArcGIS Pro, export Origins and Destinations and properly populate
+        # OriginOID and DestinationOID fields in the output Lines. Services do not preserve the original input OIDs,
+        # instead resetting from 1, unlike solves using a local network dataset.  This issue was handled on the client
+        # side in the ArcGIS Pro 3.1 release, but for older software, this extra post-processing step is necessary.
         if self.is_service and helpers.arcgis_version < "3.1":
             output_origins = os.path.join(od_workspace, "output_od_origins")
             self.logger.debug(f"Exporting OD cost matrix Origins output to {output_origins}...")
@@ -431,11 +429,10 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
         """Save the OD Lines result to a CSV file."""
         self.logger.debug(f"Saving OD cost matrix Lines output to CSV as {out_csv_file}.")
 
-        # For services solve, properly populate OriginOID and DestinationOID fields in the output Lines. Services do
-        # not preserve the original input OIDs, instead resetting from 1, unlike solves using a local network dataset,
-        # so this extra post-processing step is necessary.
-        ## TODO: Need to check service version
-        # NOTE: In 3.0, this logic is still needed.
+        # For services solve in pre-3.0 versions of ArcGIS Pro, export Origins and Destinations and properly populate
+        # OriginOID and DestinationOID fields in the output Lines. Services do not preserve the original input OIDs,
+        # instead resetting from 1, unlike solves using a local network dataset.  This issue was handled on the client
+        # side in the ArcGIS Pro 3.1 release, but for older software, this extra post-processing step is necessary.
         if self.is_service and helpers.arcgis_version < "3.1":
             # Read the Lines output
             with self.solve_result.searchCursor(

--- a/parallel_route_pairs.py
+++ b/parallel_route_pairs.py
@@ -394,6 +394,9 @@ class Route:  # pylint:disable = too-many-instance-attributes
         self.solve_result.export(arcpy.nax.RouteOutputDataType.Stops, output_stops)
 
         # Join the input ID fields to Routes
+        # New fields were added at 3.1.  Relationships between IDs/OIDs in output classes are more reliable.
+        # This may not work properly prior to 3.1.
+        id_field_prefix = "ID" if helpers.arcgis_version >= "3.1" else "OID"
         if self.reverse_direction:
             first_stop_field = self.dest_unique_id_field_name
             second_stop_field = self.origin_unique_id_field_name
@@ -403,12 +406,12 @@ class Route:  # pylint:disable = too-many-instance-attributes
         helpers.run_gp_tool(
             self.logger,
             arcpy.management.JoinField,
-            [output_routes, "FirstStopOID", output_stops, "ObjectID", [first_stop_field]]
+            [output_routes, f"FirstStop{id_field_prefix}", output_stops, "ObjectID", [first_stop_field]]
         )
         helpers.run_gp_tool(
             self.logger,
             arcpy.management.JoinField,
-            [output_routes, "LastStopOID", output_stops, "ObjectID", [second_stop_field]]
+            [output_routes, f"LastStop{id_field_prefix}", output_stops, "ObjectID", [second_stop_field]]
         )
 
         self.job_result["outputRoutes"] = output_routes

--- a/parallel_route_pairs.py
+++ b/parallel_route_pairs.py
@@ -394,9 +394,14 @@ class Route:  # pylint:disable = too-many-instance-attributes
         self.solve_result.export(arcpy.nax.RouteOutputDataType.Stops, output_stops)
 
         # Join the input ID fields to Routes
-        # New fields were added at 3.1.  Relationships between IDs/OIDs in output classes are more reliable.
-        # This may not work properly prior to 3.1.
-        id_field_prefix = "ID" if helpers.arcgis_version >= "3.1" else "OID"
+        # The new FirstStopID and LastStopID fields were added at Pro 3.1 / Enterprise 11.1 to make elationships between
+        # IDs/OIDs in output classes are more reliable.  Use these fields if they exist in the output.  Otherwise, use
+        # FirstStopOID and LastStopOID, which are mostly reliable but not perfect.  For best results, use the most
+        # recent ArcGIS software.
+        if "FirstStopID" in self.solve_result.fieldNames(arcpy.nax.RouteOutputDataType.Routes):
+            id_field_prefix = "ID"
+        else:
+            id_field_prefix = "OID"
         if self.reverse_direction:
             first_stop_field = self.dest_unique_id_field_name
             second_stop_field = self.origin_unique_id_field_name

--- a/parallel_route_pairs.py
+++ b/parallel_route_pairs.py
@@ -394,10 +394,10 @@ class Route:  # pylint:disable = too-many-instance-attributes
         self.solve_result.export(arcpy.nax.RouteOutputDataType.Stops, output_stops)
 
         # Join the input ID fields to Routes
-        # The new FirstStopID and LastStopID fields were added at Pro 3.1 / Enterprise 11.1 to make elationships between
-        # IDs/OIDs in output classes are more reliable.  Use these fields if they exist in the output.  Otherwise, use
-        # FirstStopOID and LastStopOID, which are mostly reliable but not perfect.  For best results, use the most
-        # recent ArcGIS software.
+        # The new FirstStopID and LastStopID fields were added at Pro 3.1 / Enterprise 11.1 to make relationships
+        # between IDs/OIDs in output classes are more reliable.  Use these fields if they exist in the output.
+        # Otherwise, use FirstStopOID and LastStopOID, which are mostly reliable but not perfect.  For best results, use
+        # the most recent ArcGIS software.
         if "FirstStopID" in self.solve_result.fieldNames(arcpy.nax.RouteOutputDataType.Routes):
             id_field_prefix = "ID"
         else:

--- a/unittests/test_parallel_odcm.py
+++ b/unittests/test_parallel_odcm.py
@@ -242,11 +242,7 @@ class TestParallelODCM(unittest.TestCase):
         self.assertTrue(od.job_result["solveSucceeded"], "OD solve failed")
         self.assertTrue(arcpy.Exists(od.job_result["outputLines"]), "OD line output does not exist.")
         # Ensure the OriginOID and DestinationOID fields in the output have the correct numerical ranges
-        # Note: At the ArcGIS Pro 3.1 release, the solver object output fields were improved
-        if helpers.arcgis_version < "3.1":
-            fields_to_check = ["OriginOID", "DestinationOID"]
-        else:
-            fields_to_check = ["OriginID", "DestinationID"]
+        fields_to_check = ["OriginOID", "DestinationOID"]
         for row in arcpy.da.SearchCursor(od.job_result["outputLines"], fields_to_check):
             self.assertTrue(origin_criteria[0] <= row[0] <= origin_criteria[1], f"{fields_to_check[0]} out of range.")
             self.assertTrue(dest_criteria[0] <= row[1] <= dest_criteria[1], f"{fields_to_check[1]} out of range.")

--- a/unittests/test_parallel_odcm.py
+++ b/unittests/test_parallel_odcm.py
@@ -242,9 +242,14 @@ class TestParallelODCM(unittest.TestCase):
         self.assertTrue(od.job_result["solveSucceeded"], "OD solve failed")
         self.assertTrue(arcpy.Exists(od.job_result["outputLines"]), "OD line output does not exist.")
         # Ensure the OriginOID and DestinationOID fields in the output have the correct numerical ranges
-        for row in arcpy.da.SearchCursor(od.job_result["outputLines"], ["OriginOID", "DestinationOID"]):
-            self.assertTrue(origin_criteria[0] <= row[0] <= origin_criteria[1], "OriginOID out of range.")
-            self.assertTrue(dest_criteria[0] <= row[1] <= dest_criteria[1], "DestinationOID out of range.")
+        # Note: At the ArcGIS Pro 3.1 release, the solver object output fields were improved
+        if helpers.arcgis_version < "3.1":
+            fields_to_check = ["OriginOID", "DestinationOID"]
+        else:
+            fields_to_check = ["OriginID", "DestinationID"]
+        for row in arcpy.da.SearchCursor(od.job_result["outputLines"], fields_to_check):
+            self.assertTrue(origin_criteria[0] <= row[0] <= origin_criteria[1], f"{fields_to_check[0]} out of range.")
+            self.assertTrue(dest_criteria[0] <= row[1] <= dest_criteria[1], f"{fields_to_check[1]} out of range.")
 
     def test_ODCostMatrix_solve_service_csv(self):
         """Test the solve method of the ODCostMatrix class using a service with csv output.
@@ -310,7 +315,8 @@ class TestParallelODCM(unittest.TestCase):
         od_inputs = deepcopy(self.parallel_od_class_args)
         od_inputs["travel_mode"] = "InvalidTM"
         od_calculator = parallel_odcm.ParallelODCalculator(**od_inputs)
-        with self.assertRaises(RuntimeError):
+        error_type = ValueError if helpers.arcgis_version >= "3.1" else RuntimeError
+        with self.assertRaises(error_type):
             od_calculator._validate_od_settings()
 
     def test_ParallelODCalculator_solve_od_in_parallel_featureclass(self):

--- a/unittests/test_parallel_route_pairs.py
+++ b/unittests/test_parallel_route_pairs.py
@@ -113,10 +113,37 @@ class TestParallelRoutePairs(unittest.TestCase):
         self.assertTrue(arcpy.Exists(rt.job_result["outputRoutes"]), "Route output does not exist.")
         # Expect 9 rows because two of the StoreID values are bad and are skipped
         self.assertEqual(9, int(arcpy.management.GetCount(rt.job_result["outputRoutes"]).getOutput(0)))
-        # Make sure the ID fields have been added
+        # Make sure the ID fields have been added and populated
         route_fields = [f.name for f in arcpy.ListFields(rt.job_result["outputRoutes"])]
         self.assertIn("OriginUniqueID", route_fields, "Routes output missing OriginUniqueID field.")
         self.assertIn("DestinationUniqueID", route_fields, "Routes output missing DestinationUniqueID field.")
+        for row in arcpy.da.SearchCursor(rt.job_result["outputRoutes"], ["OriginUniqueID", "DestinationUniqueID"]):
+            self.assertIsNotNone(row[0], "Null OriginUniqueID field value in output routes.")
+            self.assertIsNotNone(row[1], "Null DestinationUniqueID field value in output routes.")
+
+    def test_Route_solve_service(self):
+        """Test the solve method of the Route class with feature class output using a service."""
+        # Initialize an Route analysis object
+        route_args = deepcopy(self.route_args)
+        route_args["network_data_source"] = self.portal_nd
+        route_args["travel_mode"] = self.portal_tm
+        rt = parallel_route_pairs.Route(**route_args)
+        # Solve a chunk
+        origin_criteria = [2, 12]  # 11 rows
+        rt.solve(origin_criteria)
+        # Check results
+        self.assertIsInstance(rt.job_result, dict)
+        self.assertTrue(rt.job_result["solveSucceeded"], "Route solve failed")
+        self.assertTrue(arcpy.Exists(rt.job_result["outputRoutes"]), "Route output does not exist.")
+        # Expect 9 rows because two of the StoreID values are bad and are skipped
+        self.assertEqual(9, int(arcpy.management.GetCount(rt.job_result["outputRoutes"]).getOutput(0)))
+        # Make sure the ID fields have been added and populated
+        route_fields = [f.name for f in arcpy.ListFields(rt.job_result["outputRoutes"])]
+        self.assertIn("OriginUniqueID", route_fields, "Routes output missing OriginUniqueID field.")
+        self.assertIn("DestinationUniqueID", route_fields, "Routes output missing DestinationUniqueID field.")
+        for row in arcpy.da.SearchCursor(rt.job_result["outputRoutes"], ["OriginUniqueID", "DestinationUniqueID"]):
+            self.assertIsNotNone(row[0], "Null OriginUniqueID field value in output routes.")
+            self.assertIsNotNone(row[1], "Null DestinationUniqueID field value in output routes.")
 
     def test_ParallelRoutePairCalculator_validate_route_settings(self):
         """Test the _validate_route_settings function."""

--- a/unittests/test_parallel_route_pairs.py
+++ b/unittests/test_parallel_route_pairs.py
@@ -26,6 +26,7 @@ import input_data_helper
 CWD = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(CWD))
 import parallel_route_pairs  # noqa: E402, pylint: disable=wrong-import-position
+from helpers import arcgis_version  # noqa: E402, pylint: disable=wrong-import-position
 
 
 class TestParallelRoutePairs(unittest.TestCase):
@@ -126,7 +127,8 @@ class TestParallelRoutePairs(unittest.TestCase):
         rt_inputs = deepcopy(self.parallel_rt_class_args)
         rt_inputs["travel_mode"] = "InvalidTM"
         rt_calculator = parallel_route_pairs.ParallelRoutePairCalculator(**rt_inputs)
-        with self.assertRaises(RuntimeError):
+        error_type = ValueError if arcgis_version >= "3.1" else RuntimeError
+        with self.assertRaises(error_type):
             rt_calculator._validate_route_settings()
 
     def test_ParallelRoutePairCalculator_solve_route_in_parallel(self):

--- a/unittests/test_solve_large_odcm.py
+++ b/unittests/test_solve_large_odcm.py
@@ -27,6 +27,7 @@ CWD = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(CWD))
 import solve_large_odcm  # noqa: E402, pylint: disable=wrong-import-position
 import helpers  # noqa: E402, pylint: disable=wrong-import-position
+from helpers import arcgis_version  # noqa: E402, pylint: disable=wrong-import-position
 
 
 class TestSolveLargeODCM(unittest.TestCase):
@@ -95,7 +96,7 @@ class TestSolveLargeODCM(unittest.TestCase):
             ("barriers", [does_not_exist], ValueError, f"Input dataset {does_not_exist} does not exist."),
             ("network_data_source", does_not_exist, ValueError,
              f"Input network dataset {does_not_exist} does not exist."),
-            ("travel_mode", "BadTM", RuntimeError, ""),
+            ("travel_mode", "BadTM", ValueError if arcgis_version >= "3.1" else RuntimeError, ""),
             ("time_of_day", "3/29/2022 4:45 PM", ValueError, ""),
             ("time_of_day", "BadDateTime", ValueError, ""),
             ("cutoff", 0, ValueError, "Impedance cutoff must be greater than 0."),

--- a/unittests/test_solve_large_route_pair_analysis.py
+++ b/unittests/test_solve_large_route_pair_analysis.py
@@ -26,7 +26,7 @@ import input_data_helper
 CWD = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(CWD))
 import solve_large_route_pair_analysis  # noqa: E402, pylint: disable=wrong-import-position
-import helpers  # noqa: E402, pylint: disable=wrong-import-position
+from helpers import arcgis_version  # noqa: E402, pylint: disable=wrong-import-position
 
 
 class TestSolveLargeRoutePairAnalysis(unittest.TestCase):
@@ -94,7 +94,7 @@ class TestSolveLargeRoutePairAnalysis(unittest.TestCase):
             ("barriers", [does_not_exist], ValueError, f"Input dataset {does_not_exist} does not exist."),
             ("network_data_source", does_not_exist, ValueError,
              f"Input network dataset {does_not_exist} does not exist."),
-            ("travel_mode", "BadTM", RuntimeError, ""),
+            ("travel_mode", "BadTM", ValueError if arcgis_version >= "3.1" else RuntimeError, ""),
             ("time_of_day", "3/29/2022 4:45 PM", ValueError, ""),
             ("time_of_day", "BadDateTime", ValueError, ""),
             ("origin_id_field", "BadField", ValueError,


### PR DESCRIPTION
In the ArcGIS Pro 3.1 release, we made some improvements to the arcpy.nax solver objects, particularly in the area of ensuring reliable relationships between the output classes using OID and ID fields.  This PR makes minor updates to the tool code to ensure continuing compatibility with older versions of ArcGIS Pro and compatibility with the forthcoming 3.1 release.

I ran all unit tests with 3.0 and 3.1 and service-related tests using an 11.0 portal, an 11.1 portal, and ArcGIS Online, since the fields and values returned for those may be different because of the behavior of the arcpy.nax solver objects at different versions.  All tests are passing with these changes.