### PR TITLE
Fix logic for determining if the input layers are the same

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -245,6 +245,36 @@ def validate_input_feature_class(feature_class):
         raise ValueError(err)
 
 
+def are_input_layers_the_same(input_layer_1, input_layer_2):
+    """Determine whether two input layers are actually the same layer.
+
+    This is used, for example, to determine if the layers the user has passed in to the Origins and Destinations
+    parameters are actually the same layers.
+
+    Layer equivalency is not completely straightforward.  The value retrieved from parameter.value for a Feature Layer
+    parameter may be a layer object (if the input is a layer object/file/name), a record set object (if the input is a
+    feature set), or a GP value object (if the input is a catalog path).  This function
+    """
+    def get_layer_repr(lyr):
+        """Get the unique representation of the layer according to its type."""
+        if hasattr(lyr, "URI"):
+            # The input is a layer.  The URI property uniquely defines the layer in the map and in memory.
+            layer_repr = lyr.URI
+        elif hasattr(lyr, "JSON"):
+            # The input is a feature set.  The JSON representation of the feature set fully defines it.
+            layer_repr = lyr.JSON
+        else:
+            # The input is likely a catalog path, which is returned as a GP value object.  The string representation is
+            # the catalog path.
+            layer_repr = str(lyr)
+        return layer_repr
+
+    lyr_repr1 = get_layer_repr(input_layer_1)
+    lyr_repr2 = get_layer_repr(input_layer_2)
+
+    return lyr_repr1 == lyr_repr2
+
+
 def validate_network_data_source(network_data_source):
     """Validate the network data source and return its string-based representation.
 

--- a/solve_large_odcm.py
+++ b/solve_large_odcm.py
@@ -103,7 +103,7 @@ class ODCostMatrixSolver:  # pylint: disable=too-many-instance-attributes, too-f
         self.output_od_lines = output_od_lines
         self.output_data_folder = output_data_folder
 
-        self.same_origins_destinations = bool(self.origins == self.destinations)
+        self.same_origins_destinations = helpers.are_input_layers_the_same(self.origins, self.destinations)
 
         self.max_origins = self.chunk_size
         self.max_destinations = self.chunk_size

--- a/unittests/test_helpers.py
+++ b/unittests/test_helpers.py
@@ -1,6 +1,6 @@
 """Unit tests for the helpers.py module.
 
-Copyright 2022 Esri
+Copyright 2023 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
@@ -134,6 +134,37 @@ class TestHelpers(unittest.TestCase):
             with self.assertRaises(ValueError) as ex:
                 helpers.validate_input_feature_class(input_fc)
             self.assertEqual(f"Input dataset {input_fc} has no rows.", str(ex.exception))
+
+    def test_are_input_layers_the_same(self):
+        """Test the are_input_layers_the_same function."""
+        fc1 = os.path.join(self.sf_gdb, "Analysis", "TractCentroids")
+        fc2 = os.path.join(self.sf_gdb, "Analysis", "Hospitals")
+        lyr1_name = "Layer1"
+        lyr2_name = "Layer2"
+        lyr1_obj = arcpy.management.MakeFeatureLayer(fc1, lyr1_name)
+        lyr1_obj_again = arcpy.management.MakeFeatureLayer(fc1, "Layer1 again")
+        lyr2_obj = arcpy.management.MakeFeatureLayer(fc2, lyr2_name)
+        lyr1_file = os.path.join(self.scratch_folder, "lyr1.lyrx")
+        lyr2_file = os.path.join(self.scratch_folder, "lyr2.lyrx")
+        arcpy.management.SaveToLayerFile(lyr1_obj, lyr1_file)
+        arcpy.management.SaveToLayerFile(lyr2_obj, lyr2_file)
+        fset_1 = arcpy.FeatureSet(fc1)
+        fset_2 = arcpy.FeatureSet(fc2)
+
+        # Feature class catalog path inputs
+        self.assertFalse(helpers.are_input_layers_the_same(fc1, fc2))
+        self.assertTrue(helpers.are_input_layers_the_same(fc1, fc1))
+        # Layer inputs
+        self.assertFalse(helpers.are_input_layers_the_same(lyr1_name, lyr2_name))
+        self.assertTrue(helpers.are_input_layers_the_same(lyr1_name, lyr1_name))
+        self.assertFalse(helpers.are_input_layers_the_same(lyr1_obj, lyr2_obj))
+        self.assertTrue(helpers.are_input_layers_the_same(lyr1_obj, lyr1_obj))
+        self.assertFalse(helpers.are_input_layers_the_same(lyr1_obj, lyr1_obj_again))
+        self.assertFalse(helpers.are_input_layers_the_same(lyr1_file, lyr2_file))
+        self.assertTrue(helpers.are_input_layers_the_same(lyr1_file, lyr1_file))
+        # Feature set inputs
+        self.assertFalse(helpers.are_input_layers_the_same(fset_1, fset_2))
+        self.assertTrue(helpers.are_input_layers_the_same(fset_1, fset_1))
 
     def test_validate_network_data_source(self):
         """Test the validate_network_data_source function."""


### PR DESCRIPTION
The Solve Large OD Cost Matrix tool increases efficiency in the special case where the input origins and destinations are the same layer by only preprocessing the origins and using a copy for the destinations.  There is no need to sort and calculate network locations on the same dataset twice.

Unfortunately, the equality check for the input layers wasn't working because the item returned from accessing the input origins and destinations layers through the tool parameter (the .value property) is a separate memory instance, so even if they're the same layer, == does not return True.

This PR creates a helper function to determine if the input layers are the same.  For layers, it checks the URI, which is a reliable unique property.  For feature sets, it compares the JSON representations of the feature sets.  For catalog paths, it compares them as strings.