### PR TITLE
Retry parallel jobs that error

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -36,6 +36,7 @@ if arcgis_version >= "2.9":
 MAX_AGOL_PROCESSES = 4  # AGOL concurrent processes are limited so as not to overload the service for other users.
 MAX_RECOMMENDED_MGDB_PROCESSES = 4  # Max recommended concurrent processes with mgdb network datasets
 MAX_ALLOWED_MAX_PROCESSES = 61  # Windows limitation for concurrent.futures ProcessPoolExecutor
+MAX_RETRIES = 3  # Max allowed retries if a parallel process errors (eg, temporary service glitch or read/write error)
 DATETIME_FORMAT = "%Y%m%d %H:%M"  # Used for converting between datetime and string
 
 # Conversion between ArcGIS field types and python types for use when creating dataframes

--- a/parallel_route_pairs.py
+++ b/parallel_route_pairs.py
@@ -795,19 +795,51 @@ class ParallelRoutePairCalculator:  # pylint:disable = too-many-instance-attribu
             jobs = {executor.submit(solve_route, self.rt_inputs, range): range for range in self.chunks}
             # As each job is completed, add some logging information and store the results to post-process later
             for future in futures.as_completed(jobs):
-                completed_jobs += 1
-                LOGGER.info(
-                    f"Finished Route calculation {completed_jobs} of {self.total_jobs}.")
                 try:
                     # The Route job returns a results dictionary. Retrieve it.
                     result = future.result()
-                except Exception:
-                    # If we couldn't retrieve the result, some terrible error happened. Log it.
-                    LOGGER.error("Failed to get Route result from parallel processing.")
+                except Exception:  # pylint: disable=broad-except
+                    # If we couldn't retrieve the result, some terrible error happened and the job errored.
+                    # Note: This does not mean solve failed. It means some unexpected error was thrown. The most likely
+                    # causes are:
+                    # a) If you're calling a service, the service was temporarily down.
+                    # b) You had a temporary file read/write or resource issue on your machine.
+                    # c) If you're actively updating the code, you introduced an error.
+                    # To make the tool more robust against temporary glitches, retry submitting the job up to the number
+                    # of times designated in helpers.MAX_RETRIES.  If the job is still erroring after that many retries,
+                    # fail the entire tool run.
                     errs = traceback.format_exc().splitlines()
-                    for err in errs:
-                        LOGGER.error(err)
-                    raise
+                    failed_range = jobs[future]
+                    LOGGER.debug((
+                        f"Failed to get results for Route chunk {failed_range} from the parallel process. Will retry "
+                        f"up to {helpers.MAX_RETRIES} times. Errors: {errs}"
+                    ))
+                    job_failed = True
+                    num_retries = 0
+                    while job_failed and num_retries < helpers.MAX_RETRIES:
+                        num_retries += 1
+                        try:
+                            future = executor.submit(solve_route, self.rt_inputs, failed_range)
+                            result = future.result()
+                            job_failed = False
+                            LOGGER.debug(f"Route chunk {failed_range} succeeded after {num_retries} retries.")
+                        except Exception:  # pylint: disable=broad-except
+                            # Update exception info to the latest error
+                            errs = traceback.format_exc().splitlines()
+                    if job_failed:
+                        # The job errored and did not succeed after retries.  Fail the tool run because something
+                        # terrible is happening.
+                        LOGGER.debug(f"Route chunk {failed_range} continued to error after {num_retries} retries.")
+                        LOGGER.error("Failed to get Route result from parallel processing.")
+                        errs = traceback.format_exc().splitlines()
+                        for err in errs:
+                            LOGGER.error(err)
+                        raise
+
+                # If we got this far, the job completed successfully and we retrieved results.
+                completed_jobs += 1
+                LOGGER.info(
+                    f"Finished Route calculation {completed_jobs} of {self.total_jobs}.")
 
                 # Parse the results dictionary and store components for post-processing.
                 if result["solveSucceeded"]:


### PR DESCRIPTION
Sometimes the tool will run for a really long time and then one of the processes will throw and error, which causes the entire tool to fail. Typically we need the results of that process for the final output so it can't be skipped, but we could at least add a limited retry so the tool doesn't completely fail immediately.

Note: The errors I'm referring to do not mean failed solves.  Solves are allowed to fail and may fail for legitimate reasons, such as if no destinations were reachable from any origins within the cutoff.  What I mean is the case where some unexpected error was thrown. The most likely causes are:
- If you're calling a service, the service was temporarily down.
- You had a temporary file read/write or resource issue on your machine.
- If you're actively updating the code, you introduced an error.

This PR updates both tools to make them more robust against temporary glitches.  We now retry submitting the job up to the number of times designated in helpers.MAX_RETRIES (currently 3).  If the job is still erroring after that many retries, fail the entire tool run.

I did a good bit of testing to confirm that this is working as desired.  When you call executor.submit() in the except clause of as_completed, it just reruns the job but does not add it back into the overall ProcessPool, so we're not at risk of an infinite loop. 