### PR TITLE
Fix unicode errors

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -548,6 +548,26 @@ def execute_subprocess(script_name, inputs):
             raise RuntimeError(err)
 
 
+def configure_global_logger(log_level):
+    """Configure a global logger for the main process.
+
+    The logger logs everything from the main process to stdout using a specific format that the tools in this
+    toolbox can parse and write to the geoprocessing message feed.
+
+    Args:
+        log_level: logging module message level, such as logging.INFO or logging.DEBUG.
+    """
+    logger = logging.getLogger(__name__)  # pylint:disable=invalid-name
+    logger.setLevel(log_level)
+    sys.stdout.reconfigure(encoding="utf-8")
+    console_handler = logging.StreamHandler(stream=sys.stdout)
+    console_handler.setLevel(log_level)
+    # Used by script tool to split message text from message level to add correct message type to GP window
+    console_handler.setFormatter(logging.Formatter("%(levelname)s" + MSG_STR_SPLITTER + "%(message)s"))
+    logger.addHandler(console_handler)
+    return logger
+
+
 def parse_std_and_write_to_gp_ui(msg_string):
     """Parse a message string returned from the subprocess's stdout and write it to the GP UI according to type.
 

--- a/helpers.py
+++ b/helpers.py
@@ -525,7 +525,7 @@ def execute_subprocess(script_name, inputs):
         while process.poll() is None:
             output = process.stdout.readline()
             if output:
-                msg_string = output.strip().decode()
+                msg_string = output.strip().decode(encoding="utf-8")
                 parse_std_and_write_to_gp_ui(msg_string)
             time.sleep(.1)
 
@@ -534,7 +534,7 @@ def execute_subprocess(script_name, inputs):
         # messages from raised exceptions, especially those with tracebacks.
         output, _ = process.communicate()
         if output:
-            out_msgs = output.decode().splitlines()
+            out_msgs = output.decode(encoding="utf-8").splitlines()
             for msg in out_msgs:
                 parse_std_and_write_to_gp_ui(msg)
 
@@ -747,7 +747,7 @@ class LoggingMixin:
 
         self.logger.setLevel(logging.DEBUG)
         if len(self.logger.handlers) <= 1:
-            file_handler = logging.FileHandler(self.log_file)
+            file_handler = logging.FileHandler(self.log_file, encoding="utf-8")
             file_handler.setLevel(logging.DEBUG)
             self.logger.addHandler(file_handler)
             formatter = logging.Formatter("%(process)d | %(message)s")

--- a/parallel_calculate_locations.py
+++ b/parallel_calculate_locations.py
@@ -33,7 +33,6 @@ Copyright 2023 Esri
 # pylint: disable=logging-fstring-interpolation
 from concurrent import futures
 import os
-import sys
 import uuid
 import logging
 import shutil
@@ -45,21 +44,10 @@ import arcpy
 
 import helpers
 
-arcpy.env.overwriteOutput = True
-
-# Set logging for the main process.
-# LOGGER logs everything from the main process to stdout using a specific format that the calling tool
-# can parse and write to the geoprocessing message feed.
-LOG_LEVEL = logging.INFO  # Set to logging.DEBUG to see verbose debug messages
-LOGGER = logging.getLogger(__name__)  # pylint:disable=invalid-name
-LOGGER.setLevel(LOG_LEVEL)
-console_handler = logging.StreamHandler(stream=sys.stdout)
-console_handler.setLevel(LOG_LEVEL)
-# Used by script tool to split message text from message level to add correct message type to GP window
-console_handler.setFormatter(logging.Formatter("%(levelname)s" + helpers.MSG_STR_SPLITTER + "%(message)s"))
-LOGGER.addHandler(console_handler)
-
 DELETE_INTERMEDIATE_OUTPUTS = True  # Set to False for debugging purposes
+
+# Change logging.INFO to logging.DEBUG to see verbose debug messages
+LOGGER = helpers.configure_global_logger(logging.INFO)
 
 
 class LocationCalculator(
@@ -426,4 +414,5 @@ def launch_parallel_calc_locs():
 
 if __name__ == "__main__":
     # This script should always be launched via subprocess as if it were being called from the command line.
-    launch_parallel_calc_locs()
+    with arcpy.EnvManager(overwriteOutput=True):
+        launch_parallel_calc_locs()

--- a/parallel_odcm.py
+++ b/parallel_odcm.py
@@ -26,7 +26,6 @@ Copyright 2023 Esri
 # pylint: disable=logging-fstring-interpolation
 from concurrent import futures
 import os
-import sys
 import uuid
 import logging
 import shutil
@@ -52,21 +51,10 @@ if helpers.arcgis_version >= "2.9":
     import pyarrow as pa
     from pyarrow import fs
 
-arcpy.env.overwriteOutput = True
-
-# Set logging for the main process.
-# LOGGER logs everything from the main process to stdout using a specific format that the SolveLargeODCostMatrix tool
-# can parse and write to the geoprocessing message feed.
-LOG_LEVEL = logging.INFO  # Set to logging.DEBUG to see verbose debug messages
-LOGGER = logging.getLogger(__name__)  # pylint:disable=invalid-name
-LOGGER.setLevel(LOG_LEVEL)
-console_handler = logging.StreamHandler(stream=sys.stdout)
-console_handler.setLevel(LOG_LEVEL)
-# Used by script tool to split message text from message level to add correct message type to GP window
-console_handler.setFormatter(logging.Formatter("%(levelname)s" + helpers.MSG_STR_SPLITTER + "%(message)s"))
-LOGGER.addHandler(console_handler)
-
 DELETE_INTERMEDIATE_OD_OUTPUTS = True  # Set to False for debugging purposes
+
+# Change logging.INFO to logging.DEBUG to see verbose debug messages
+LOGGER = helpers.configure_global_logger(logging.INFO)
 
 
 class ODCostMatrix(
@@ -1172,4 +1160,5 @@ def launch_parallel_od():
 
 if __name__ == "__main__":
     # This script should always be launched via subprocess as if it were being called from the command line.
-    launch_parallel_od()
+    with arcpy.EnvManager(overwriteOutput=True):
+        launch_parallel_od()

--- a/parallel_route_pairs.py
+++ b/parallel_route_pairs.py
@@ -29,7 +29,6 @@ Copyright 2023 Esri
 # pylint: disable=logging-fstring-interpolation
 from concurrent import futures
 import os
-import sys
 import logging
 import shutil
 import time
@@ -47,21 +46,10 @@ from rt_config import RT_PROPS, RT_PROPS_SET_BY_TOOL
 
 import helpers
 
-arcpy.env.overwriteOutput = True
-
-# Set logging for the main process.
-# LOGGER logs everything from the main process to stdout using a specific format that the SolveLargeRoute tool
-# can parse and write to the geoprocessing message feed.
-LOG_LEVEL = logging.INFO  # Set to logging.DEBUG to see verbose debug messages
-LOGGER = logging.getLogger(__name__)  # pylint:disable=invalid-name
-LOGGER.setLevel(LOG_LEVEL)
-console_handler = logging.StreamHandler(stream=sys.stdout)
-console_handler.setLevel(LOG_LEVEL)
-# Used by script tool to split message text from message level to add correct message type to GP window
-console_handler.setFormatter(logging.Formatter("%(levelname)s" + helpers.MSG_STR_SPLITTER + "%(message)s"))
-LOGGER.addHandler(console_handler)
-
 DELETE_INTERMEDIATE_OUTPUTS = True  # Set to False for debugging purposes
+
+# Change logging.INFO to logging.DEBUG to see verbose debug messages
+LOGGER = helpers.configure_global_logger(logging.INFO)
 
 
 class Route(
@@ -976,4 +964,5 @@ def launch_parallel_rt_pairs():
 
 if __name__ == "__main__":
     # This script should always be launched via subprocess as if it were being called from the command line.
-    launch_parallel_rt_pairs()
+    with arcpy.EnvManager(overwriteOutput=True):
+        launch_parallel_rt_pairs()

--- a/parallel_route_pairs.py
+++ b/parallel_route_pairs.py
@@ -503,16 +503,17 @@ class Route(
         else:
             first_stop_field = self.origin_unique_id_field_name
             second_stop_field = self.dest_unique_id_field_name
-        helpers.run_gp_tool(
-            self.logger,
-            arcpy.management.JoinField,
-            [output_routes, f"FirstStop{id_field_prefix}", output_stops, "ObjectID", [first_stop_field]]
-        )
-        helpers.run_gp_tool(
-            self.logger,
-            arcpy.management.JoinField,
-            [output_routes, f"LastStop{id_field_prefix}", output_stops, "ObjectID", [second_stop_field]]
-        )
+        with arcpy.EnvManager(overwriteOutput=True):
+            helpers.run_gp_tool(
+                self.logger,
+                arcpy.management.JoinField,
+                [output_routes, f"FirstStop{id_field_prefix}", output_stops, "ObjectID", [first_stop_field]]
+            )
+            helpers.run_gp_tool(
+                self.logger,
+                arcpy.management.JoinField,
+                [output_routes, f"LastStop{id_field_prefix}", output_stops, "ObjectID", [second_stop_field]]
+            )
 
         self.job_result["outputRoutes"] = output_routes
 


### PR DESCRIPTION
A couple of users have gotten errors like "UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 81: invalid continuation byte". It took me a while to fix it because I couldn't reproduce it, and I still don't know exactly what caused it. However, someone who experienced the problem ran some tests for me and confirmed that the various encoding/decoding changes here resolve the problem. I think it has something to do with non-ascii characters either in logging to stdout or in filepath names of temporary files or scratch folders or something.