### PR TITLE
Refactor logging in subprocesses

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -590,6 +590,13 @@ def parse_std_and_write_to_gp_ui(msg_string):
         arcpy.AddMessage(msg_string)
 
 
+def teardown_logger(logger):
+    """Clean up and close the logger."""
+    for handler in logger.handlers:
+        handler.close()
+        logger.removeHandler(handler)
+
+
 def run_gp_tool(log_to_use, tool, tool_args=None, tool_kwargs=None):
     """Run a geoprocessing tool with nice logging.
 
@@ -839,9 +846,7 @@ class LoggingMixin:
 
     def teardown_logger(self):
         """Clean up and close the logger."""
-        for handler in self.logger.handlers:
-            handler.close()
-            self.logger.removeHandler(handler)
+        teardown_logger(self.logger)
 
 
 class MakeNDSLayerMixin:  # pylint:disable = too-few-public-methods

--- a/parallel_calculate_locations.py
+++ b/parallel_calculate_locations.py
@@ -46,7 +46,7 @@ import helpers
 DELETE_INTERMEDIATE_OUTPUTS = True  # Set to False for debugging purposes
 
 # Change logging.INFO to logging.DEBUG to see verbose debug messages
-LOGGER = helpers.configure_global_logger(logging.INFO)
+LOG_LEVEL = logging.INFO
 
 
 class LocationCalculator(
@@ -161,7 +161,7 @@ class ParallelLocationCalculator:
     """Calculate network locations for a large dataset by chunking the dataset and calculating in parallel."""
 
     def __init__(  # pylint: disable=too-many-locals, too-many-arguments
-        self, input_features, output_features, network_data_source, chunk_size, max_processes,
+        self, logger, input_features, output_features, network_data_source, chunk_size, max_processes,
         travel_mode=None, search_tolerance=None, search_criteria=None, search_query=None
     ):
         """Calculate network locations for the input features in parallel.
@@ -171,6 +171,8 @@ class ParallelLocationCalculator:
         https://pro.arcgis.com/en/pro-app/latest/tool-reference/network-analyst/calculate-locations.htm
 
         Args:
+            logger (logging.logger): Logger class to use for messages that get written to the GP window. Set up using
+                helpers.configure_global_logger().
             input_features (str): Catalog path to input features to calculate locations for
             output_features (str): Catalog path to the location where the output updated feature class will be saved.
                 Unlike in the core Calculate Locations tool, this tool generates a new feature class instead of merely
@@ -190,11 +192,14 @@ class ParallelLocationCalculator:
         self.output_features = output_features
         self.max_processes = max_processes
 
+        # Set up logger that will write to the GP window
+        self.logger = logger
+
         # Scratch folder to store intermediate outputs from the OD Cost Matrix processes
         unique_id = uuid.uuid4().hex
         self.scratch_folder = os.path.join(
             arcpy.env.scratchFolder, "CalcLocs_" + unique_id)  # pylint: disable=no-member
-        LOGGER.info(f"Intermediate outputs will be written to {self.scratch_folder}.")
+        self.logger.info(f"Intermediate outputs will be written to {self.scratch_folder}.")
         os.mkdir(self.scratch_folder)
 
         # Dictionary of static input settings to send to the parallel location calculator
@@ -218,7 +223,7 @@ class ParallelLocationCalculator:
         """Calculate locations in parallel."""
         # Calculate locations in parallel
         job_results = helpers.run_parallel_processes(
-            LOGGER, calculate_locations_for_chunk, [self.calc_locs_inputs], self.ranges,
+            self.logger, calculate_locations_for_chunk, [self.calc_locs_inputs], self.ranges,
             len(self.ranges), self.max_processes,
             "Calculating locations", "Calculate Locations"
         )
@@ -228,21 +233,21 @@ class ParallelLocationCalculator:
             self.temp_out_fcs[result["oidRange"]] = result["outputFC"]
 
         # Rejoin the chunked feature classes into one.
-        LOGGER.info("Rejoining chunked data...")
+        self.logger.info("Rejoining chunked data...")
         self._rejoin_chunked_output()
 
         # Clean up
         # Delete the job folders if the job succeeded
         if DELETE_INTERMEDIATE_OUTPUTS:
-            LOGGER.info("Deleting intermediate outputs...")
+            self.logger.info("Deleting intermediate outputs...")
             try:
                 shutil.rmtree(self.scratch_folder, ignore_errors=True)
             except Exception:  # pylint: disable=broad-except
                 # If deletion doesn't work, just throw a warning and move on. This does not need to kill the tool.
-                LOGGER.warning(
+                self.logger.warning(
                     f"Unable to delete intermediate Calculate Locations output folder {self.scratch_folder}.")
 
-        LOGGER.info("Finished calculating locations in parallel.")
+        self.logger.info("Finished calculating locations in parallel.")
 
     def _rejoin_chunked_output(self):
         """Merge the chunks into a single feature class.
@@ -251,11 +256,11 @@ class ParallelLocationCalculator:
         using the Merge geoprocessing tool.
         """
         # Create the final output feature class
-        LOGGER.debug("Creating output feature class...")
+        self.logger.debug("Creating output feature class...")
         template_fc = self.temp_out_fcs[tuple(self.ranges[0])]
         desc = arcpy.Describe(template_fc)
         helpers.run_gp_tool(
-            LOGGER,
+            self.logger,
             arcpy.management.CreateFeatureclass, [
                 os.path.dirname(self.output_features),
                 os.path.basename(self.output_features),
@@ -268,7 +273,7 @@ class ParallelLocationCalculator:
         )
 
         # Insert the rows from all the individual output feature classes into the final output
-        LOGGER.debug("Inserting rows into output feature class from output chunks...")
+        self.logger.debug("Inserting rows into output feature class from output chunks...")
         fields = ["SHAPE@"] + [f.name for f in desc.fields]
         with arcpy.da.InsertCursor(self.output_features, fields) as cur:  # pylint: disable=no-member
             # Get rows from the output feature class from each chunk in the original order
@@ -339,23 +344,28 @@ def launch_parallel_calc_locs():
         "-sq", "--search-query", action="store", dest="search_query", help=help_string, required=False)
 
     try:
+        logger = helpers.configure_global_logger(LOG_LEVEL)
+
         # Get arguments as dictionary.
         args = vars(parser.parse_args())
+        args["logger"] = logger
 
         # Initialize a parallel location calculator class
         cl_calculator = ParallelLocationCalculator(**args)
         # Calculate network locations in parallel chunks
         start_time = time.time()
         cl_calculator.calc_locs_in_parallel()
-        LOGGER.info(f"Parallel Calculate Locations completed in {round((time.time() - start_time) / 60, 2)} minutes")
+        logger.info(f"Parallel Calculate Locations completed in {round((time.time() - start_time) / 60, 2)} minutes")
 
     except Exception:  # pylint: disable=broad-except
-        LOGGER.error("Error in parallelization subprocess.")
+        logger.error("Error in parallelization subprocess.")
         errs = traceback.format_exc().splitlines()
         for err in errs:
-            LOGGER.error(err)
+            logger.error(err)
         raise
 
+    finally:
+        helpers.teardown_logger(logger)
 
 if __name__ == "__main__":
     # This script should always be launched via subprocess as if it were being called from the command line.

--- a/unittests/test_parallel_calculate_locations.py
+++ b/unittests/test_parallel_calculate_locations.py
@@ -23,6 +23,7 @@ import arcpy
 CWD = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(CWD))
 import parallel_calculate_locations  # noqa: E402, pylint: disable=wrong-import-position
+from helpers import configure_global_logger, teardown_logger
 
 
 class TestParallelCalculateLocations(unittest.TestCase):
@@ -112,7 +113,9 @@ class TestParallelCalculateLocations(unittest.TestCase):
         fc_to_precalculate = os.path.join(self.output_gdb, "PrecalcFC_Parallel")
         arcpy.management.Copy(self.input_fc, fc_to_precalculate)
         out_fc = os.path.join(self.output_gdb, "PrecalcFC_Parallel_out")
+        logger = configure_global_logger(parallel_calculate_locations.LOG_LEVEL)
         inputs = {
+            "logger": logger,
             "input_features": fc_to_precalculate,
             "output_features": out_fc,
             "chunk_size": 6,
@@ -123,15 +126,18 @@ class TestParallelCalculateLocations(unittest.TestCase):
             "search_criteria": [["Streets", "SHAPE"], ["Streets_ND_Junctions", "SHAPE"]],
             "search_query": [["Streets", "ObjectID <> 1"], ["Streets_ND_Junctions", ""]]
         }
-        parallel_calculator = parallel_calculate_locations.ParallelLocationCalculator(**inputs)
-        parallel_calculator.calc_locs_in_parallel()
-        self.assertTrue(arcpy.Exists(out_fc), "Output fc does not exist.")
-        self.assertEqual(
-            int(arcpy.management.GetCount(self.input_fc).getOutput(0)),
-            int(arcpy.management.GetCount(out_fc).getOutput(0)),
-            "Output feature class doesn't have the same number of rows as the original input."
-        )
-        self.check_precalculated_locations(out_fc, check_has_values=True)
+        try:
+            parallel_calculator = parallel_calculate_locations.ParallelLocationCalculator(**inputs)
+            parallel_calculator.calc_locs_in_parallel()
+            self.assertTrue(arcpy.Exists(out_fc), "Output fc does not exist.")
+            self.assertEqual(
+                int(arcpy.management.GetCount(self.input_fc).getOutput(0)),
+                int(arcpy.management.GetCount(out_fc).getOutput(0)),
+                "Output feature class doesn't have the same number of rows as the original input."
+            )
+            self.check_precalculated_locations(out_fc, check_has_values=True)
+        finally:
+            teardown_logger(logger)
 
     def test_cli(self):
         """Test the command line interface."""

--- a/unittests/test_parallel_odcm.py
+++ b/unittests/test_parallel_odcm.py
@@ -80,7 +80,10 @@ class TestParallelODCM(unittest.TestCase):
             "barriers": []
         }
 
+        self.logger = helpers.configure_global_logger(parallel_odcm.LOG_LEVEL)
+
         self.parallel_od_class_args = {
+            "logger": self.logger,
             "origins": self.origins,
             "destinations": self.destinations,
             "network_data_source": self.local_nd,
@@ -97,6 +100,11 @@ class TestParallelODCM(unittest.TestCase):
             "time_of_day": "20220329 16:45",
             "barriers": []
         }
+
+    @classmethod
+    def tearDownClass(self):
+        """Deconstruct the logger when tests are finished."""
+        helpers.teardown_logger(self.logger)
 
     def test_ODCostMatrix_hour_to_time_units(self):
         """Test the _hour_to_time_units method of the ODCostMatrix class."""
@@ -319,6 +327,7 @@ class TestParallelODCM(unittest.TestCase):
         """Test the solve_od_in_parallel function. Output to feature class."""
         out_od_lines = os.path.join(self.output_gdb, "Out_OD_Lines")
         inputs = {
+            "logger": self.logger,
             "origins": self.origins,
             "destinations": self.destinations,
             "network_data_source": self.local_nd,
@@ -353,6 +362,7 @@ class TestParallelODCM(unittest.TestCase):
         """
         out_od_lines = os.path.join(self.output_gdb, "Out_OD_Lines_NoLimit")
         inputs = {
+            "logger": self.logger,
             "origins": self.origins,
             "destinations": self.destinations,
             "network_data_source": self.local_nd,
@@ -383,6 +393,7 @@ class TestParallelODCM(unittest.TestCase):
         out_folder = os.path.join(self.scratch_folder, "ParallelODCalculator_CSV")
         os.mkdir(out_folder)
         inputs = {
+            "logger": self.logger,
             "origins": self.origins,
             "destinations": self.destinations,
             "network_data_source": self.local_nd,
@@ -418,6 +429,7 @@ class TestParallelODCM(unittest.TestCase):
         out_folder = os.path.join(self.scratch_folder, "ParallelODCalculator_Arrow")
         os.mkdir(out_folder)
         inputs = {
+            "logger": self.logger,
             "origins": self.origins,
             "destinations": self.destinations,
             "network_data_source": self.local_nd,

--- a/unittests/test_parallel_odcm.py
+++ b/unittests/test_parallel_odcm.py
@@ -136,21 +136,22 @@ class TestParallelODCM(unittest.TestCase):
         od = parallel_odcm.ODCostMatrix(**self.od_args)
         origin_criteria = [1, 2]  # Encompasses 2 rows in the southwest corner
 
-        # Test when a subset of destinations meets the cutoff criteria
-        dest_criteria = [8, 12]  # Encompasses 5 rows. Two are close to the origins.
-        od._select_inputs(origin_criteria, dest_criteria)
-        self.assertEqual(2, int(arcpy.management.GetCount(od.input_origins_layer_obj).getOutput(0)))
-        # Only two destinations fall within the distance threshold
-        self.assertEqual(2, int(arcpy.management.GetCount(od.input_destinations_layer_obj).getOutput(0)))
+        with arcpy.EnvManager(overwriteOutput=True):
+            # Test when a subset of destinations meets the cutoff criteria
+            dest_criteria = [8, 12]  # Encompasses 5 rows. Two are close to the origins.
+            od._select_inputs(origin_criteria, dest_criteria)
+            self.assertEqual(2, int(arcpy.management.GetCount(od.input_origins_layer_obj).getOutput(0)))
+            # Only two destinations fall within the distance threshold
+            self.assertEqual(2, int(arcpy.management.GetCount(od.input_destinations_layer_obj).getOutput(0)))
 
-        # Test when none of the destinations are within the threshold
-        dest_criteria = [14, 17]  # Encompasses 4 locations in the far northeast corner
-        od._select_inputs(origin_criteria, dest_criteria)
-        self.assertEqual(2, int(arcpy.management.GetCount(od.input_origins_layer_obj).getOutput(0)))
-        self.assertIsNone(
-            od.input_destinations_layer_obj,
-            "Destinations layer should be None since no destinations fall within the straight-line cutoff of origins."
-        )
+            # Test when none of the destinations are within the threshold
+            dest_criteria = [14, 17]  # Encompasses 4 locations in the far northeast corner
+            od._select_inputs(origin_criteria, dest_criteria)
+            self.assertEqual(2, int(arcpy.management.GetCount(od.input_origins_layer_obj).getOutput(0)))
+            self.assertIsNone(
+                od.input_destinations_layer_obj,
+                "Destinations layer should be None since no destinations fall within the straight-line cutoff of origins."
+            )
 
     def test_ODCostMatrix_solve_featureclass(self):
         """Test the solve method of the ODCostMatrix class with feature class output."""

--- a/unittests/test_parallel_route_pairs.py
+++ b/unittests/test_parallel_route_pairs.py
@@ -27,7 +27,7 @@ import input_data_helper
 CWD = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(CWD))
 import parallel_route_pairs  # noqa: E402, pylint: disable=wrong-import-position
-from helpers import arcgis_version, PreassignedODPairType  # noqa: E402, pylint: disable=wrong-import-position
+from helpers import arcgis_version, PreassignedODPairType, configure_global_logger, teardown_logger
 
 
 class TestParallelRoutePairs(unittest.TestCase):
@@ -57,6 +57,7 @@ class TestParallelRoutePairs(unittest.TestCase):
         os.makedirs(self.output_folder)
         self.output_gdb = os.path.join(self.output_folder, "outputs.gdb")
         arcpy.management.CreateFileGDB(os.path.dirname(self.output_gdb), os.path.basename(self.output_gdb))
+        self.logger = configure_global_logger(parallel_route_pairs.LOG_LEVEL)
 
         self.route_args_one_to_one = {
             "pair_type": PreassignedODPairType.one_to_one,
@@ -97,6 +98,7 @@ class TestParallelRoutePairs(unittest.TestCase):
             "barriers": []
         }
         self.parallel_rt_class_args_one_to_one = {
+            "logger": self.logger,
             "pair_type_str": "one_to_one",
             "origins": self.origins,
             "origin_id_field": "ID",
@@ -117,6 +119,7 @@ class TestParallelRoutePairs(unittest.TestCase):
             "barriers": ""
         }
         self.parallel_rt_class_args_many_to_many = {
+            "logger": self.logger,
             "pair_type_str": "many_to_many",
             "origins": self.origins,
             "origin_id_field": "ID",
@@ -136,6 +139,11 @@ class TestParallelRoutePairs(unittest.TestCase):
             "time_of_day": "20220329 16:45",
             "barriers": ""
         }
+
+    @classmethod
+    def tearDownClass(self):
+        """Deconstruct the logger when tests are finished."""
+        teardown_logger(self.logger)
 
     def test_Route_get_od_pairs_for_chunk(self):
         """Test the _get_od_pairs_for_chunk method of the Route class."""


### PR DESCRIPTION
Restructure how the loggers in the subprocesses are initialized.  They should not be initialized when the module is imported but rather only initialized when needed.

No substantive changes to the tools in this PR, just some code clean-up and improvement.