### PR TITLE
Support 64bit ObjectIDs

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -46,6 +46,7 @@ MAX_RECOMMENDED_MGDB_PROCESSES = 4  # Max recommended concurrent processes with 
 MAX_ALLOWED_MAX_PROCESSES = 61  # Windows limitation for concurrent.futures ProcessPoolExecutor
 MAX_RETRIES = 3  # Max allowed retries if a parallel process errors (eg, temporary service glitch or read/write error)
 DATETIME_FORMAT = "%Y%m%d %H:%M"  # Used for converting between datetime and string
+MAX_ALLOWED_FC_ROWS_32BIT = 2000000000  # Use a 64bit OID feature class if the row count is bigger than this
 
 # Conversion between ArcGIS field types and python types for use when creating dataframes
 PD_FIELD_TYPES = {"String": str, "Single": float, "Double": float, "SmallInteger": int, "Integer": int, "OID": int}
@@ -486,6 +487,19 @@ def make_oid_preserving_field_mappings(input_fc, oid_field_name, unique_id_field
     # Add the new field map
     field_mappings.addFieldMap(new_fm)
     return field_mappings
+
+
+def get_max_possible_od_pair_count(origins_fc, destinations_fc, num_dests_to_find):
+    """Return the maximum number of OD pairs the results may include.
+
+    Used by the OD Cost Matrix solver only.
+    """
+    origin_count = int(arcpy.management.GetCount(origins_fc).getOutput(0))
+    if num_dests_to_find:
+        dest_count = num_dests_to_find
+    else:
+        dest_count = int(arcpy.management.GetCount(destinations_fc).getOutput(0))
+    return origin_count * dest_count
 
 
 def execute_subprocess(script_name, inputs):

--- a/helpers.py
+++ b/helpers.py
@@ -479,7 +479,10 @@ def make_oid_preserving_field_mappings(input_fc, oid_field_name, unique_id_field
     new_field = arcpy.Field()
     new_field.name = unique_id_field_name
     new_field.aliasName = "Original OID"
-    new_field.type = "Integer"
+    if arcgis_version >= "3.2" and arcpy.Describe(input_fc).hasOID64:
+        new_field.type = "BigInteger"
+    else:
+        new_field.type = "Integer"
     # Create a new field map object and map the ObjectID to the new output field
     new_fm = arcpy.FieldMap()
     new_fm.addInputField(input_fc, oid_field_name)

--- a/helpers.py
+++ b/helpers.py
@@ -21,6 +21,7 @@ import enum
 import traceback
 import logging
 import subprocess
+from numpy import int64
 from concurrent import futures
 import arcpy
 
@@ -29,6 +30,8 @@ arcgis_version = arcpy.GetInstallInfo()["Version"]
 
 # Set some shared global variables that can be referenced from the other scripts
 ID_FIELD_TYPES = ["Short", "Long", "Double", "Single", "Text", "OID"]
+if arcgis_version >= "3.2":
+    ID_FIELD_TYPES.append("BigInteger")
 MSG_STR_SPLITTER = " | "
 DISTANCE_UNITS = ["Kilometers", "Meters", "Miles", "Yards", "Feet", "NauticalMiles"]
 TIME_UNITS = ["Days", "Hours", "Minutes", "Seconds"]
@@ -49,7 +52,9 @@ DATETIME_FORMAT = "%Y%m%d %H:%M"  # Used for converting between datetime and str
 MAX_ALLOWED_FC_ROWS_32BIT = 2000000000  # Use a 64bit OID feature class if the row count is bigger than this
 
 # Conversion between ArcGIS field types and python types for use when creating dataframes
-PD_FIELD_TYPES = {"String": str, "Single": float, "Double": float, "SmallInteger": int, "Integer": int, "OID": int}
+PD_FIELD_TYPES = {
+    "String": str, "Single": float, "Double": float, "SmallInteger": int, "Integer": int, "OID": int,
+    "BigInteger": int64}
 
 
 def is_nds_service(network_data_source):

--- a/parallel_route_pairs.py
+++ b/parallel_route_pairs.py
@@ -36,6 +36,7 @@ import traceback
 import argparse
 from math import ceil
 from distutils.util import strtobool
+from numpy import int64
 import pandas as pd
 
 import arcpy
@@ -253,7 +254,7 @@ class Route(
         # Select the origins present in this chunk of predefined OD pairs
         self.logger.debug("Selecting origins for this chunk...")
         origins_in_chunk = set([pair[0] for pair in self.od_pairs])
-        if isinstance(self.od_pairs[0][0], (int, float,)):
+        if isinstance(self.od_pairs[0][0], (int, float, int64,)):
             origin_string = ", ".join([str(o_id) for o_id in origins_in_chunk])
         else:
             origin_string = "'" + "', '".join([str(o_id) for o_id in origins_in_chunk]) + "'"
@@ -269,7 +270,7 @@ class Route(
         # Select the destinations present in this chunk of predefined OD pairs
         self.logger.debug("Selecting destinations for this chunk...")
         dests_in_chunk = set([pair[1] for pair in self.od_pairs])
-        if isinstance(self.od_pairs[0][1], (int, float,)):
+        if isinstance(self.od_pairs[0][1], (int, float, int64,)):
             dest_string = ", ".join([str(d_id) for d_id in dests_in_chunk])
         else:
             dest_string = "'" + "', '".join([str(d_id) for d_id in dests_in_chunk]) + "'"

--- a/parallel_route_pairs.py
+++ b/parallel_route_pairs.py
@@ -187,7 +187,7 @@ class Route(
     def _add_unique_id_fields(self):
         """Add fields to input Stops with the origin and destination's original unique IDs."""
         field_types = {"String": "TEXT", "Single": "FLOAT", "Double": "DOUBLE", "SmallInteger": "SHORT",
-                       "Integer": "LONG", "OID": "LONG"}
+                       "Integer": "LONG", "OID": "LONG", "BigInteger": "BIGINTEGER"}
         origin_field_def = [self.origin_unique_id_field_name, field_types[self.origin_id_field_obj.type]]
         if self.origin_id_field_obj.type == "String":
             origin_field_def += [self.origin_unique_id_field_name, self.origin_id_field_obj.length]

--- a/solve_large_route_pair_analysis.py
+++ b/solve_large_route_pair_analysis.py
@@ -516,6 +516,9 @@ class RoutePairSolver(
             self.origin_id_field = f"OID_{self.unique_id}"
             field_mappings = helpers.make_oid_preserving_field_mappings(
                 self.origins, origins_oid_field, self.origin_id_field)
+            # If the assigned destination ID field is ObjectID, remap to the preserved OID field name instead
+            if self.assigned_dest_field == origins_oid_field:
+                self.assigned_dest_field = self.origin_id_field
         arcpy.conversion.FeatureClassToFeatureClass(
             self.origins,
             os.path.dirname(self.output_origins),
@@ -539,7 +542,7 @@ class RoutePairSolver(
 
         # Sort origins by assigned destination if relevant
         if self.pair_type is helpers.PreassignedODPairType.one_to_one and self.should_sort_origins:
-            if self.assigned_dest_field == dest_oid_field:
+            if self.assigned_dest_field == origins_oid_field:
                 arcpy.AddWarning((
                     "When using the ObjectID field in Origins as the assigned destination field, the origins table "
                     "cannot and does not need to be sorted."))


### PR DESCRIPTION
Correctly handle 64bit OID inputs and the case where the output feature class needs a 64bit OID to support the size of the result.
At least partially satisfies https://github.com/Esri/large-network-analysis-tools/issues/49, but the user who reported the problem has an additional problem that I can't reproduce.