### PR TITLE
Fix cutoff units

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -2,7 +2,7 @@
 
 This is a sample script users can modify to fit their specific needs.
 
-Copyright 2023 Esri
+Copyright 2024 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/parallel_calculate_locations.py
+++ b/parallel_calculate_locations.py
@@ -19,7 +19,7 @@ within ArcGIS Pro, cannot launch parallel subprocesses on its own.
 
 This script should not be called directly from the command line.
 
-Copyright 2023 Esri
+Copyright 2024 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/parallel_odcm.py
+++ b/parallel_odcm.py
@@ -50,10 +50,10 @@ if helpers.arcgis_version >= "2.9":
     import pyarrow as pa
     from pyarrow import fs
 
-DELETE_INTERMEDIATE_OD_OUTPUTS = True  # Set to False for debugging purposes
+DELETE_INTERMEDIATE_OD_OUTPUTS = False  # Set to False for debugging purposes
 
 # Change logging.INFO to logging.DEBUG to see verbose debug messages
-LOG_LEVEL = logging.INFO
+LOG_LEVEL = logging.DEBUG
 
 
 class ODCostMatrix(
@@ -185,9 +185,9 @@ class ODCostMatrix(
         self.od_solver.travelMode = self.travel_mode
         self.logger.debug(f"travelMode: {self.travel_mode}")
         self.od_solver.timeUnits = self.time_units
-        self.logger.debug(f"timeUnits: {self.time_units}")
+        self.logger.debug(f"timeUnits: {self.time_units.name}")
         self.od_solver.distanceUnits = self.distance_units
-        self.logger.debug(f"distanceUnits: {self.distance_units}")
+        self.logger.debug(f"distanceUnits: {self.distance_units.name}")
         self.od_solver.defaultDestinationCount = self.num_destinations
         self.logger.debug(f"defaultDestinationCount: {self.num_destinations}")
         self.od_solver.defaultImpedanceCutoff = self.cutoff
@@ -205,15 +205,15 @@ class ODCostMatrix(
             origins_criteria (list): Origin ObjectID range to select from the input dataset
             destinations_criteria ([type]): Destination ObjectID range to select from the input dataset
         """
+        # Initialize the OD solver object
+        self.initialize_od_solver()
+
         # Select the origins and destinations to process
         self._select_inputs(origins_criteria, destinations_criteria)
         if not self.input_destinations_layer_obj:
             # No destinations met the criteria for this set of origins
             self.logger.debug("No destinations met the criteria for this set of origins. Skipping OD calculation.")
             return
-
-        # Initialize the OD solver object
-        self.initialize_od_solver()
 
         # Load the origins
         self.logger.debug("Loading origins...")

--- a/parallel_odcm.py
+++ b/parallel_odcm.py
@@ -12,7 +12,7 @@ within ArcGIS Pro, cannot launch parallel subprocesses on its own.
 
 This script should not be called directly from the command line.
 
-Copyright 2023 Esri
+Copyright 2024 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/parallel_odcm.py
+++ b/parallel_odcm.py
@@ -50,10 +50,10 @@ if helpers.arcgis_version >= "2.9":
     import pyarrow as pa
     from pyarrow import fs
 
-DELETE_INTERMEDIATE_OD_OUTPUTS = False  # Set to False for debugging purposes
+DELETE_INTERMEDIATE_OD_OUTPUTS = True  # Set to False for debugging purposes
 
 # Change logging.INFO to logging.DEBUG to see verbose debug messages
-LOG_LEVEL = logging.DEBUG
+LOG_LEVEL = logging.INFO
 
 
 class ODCostMatrix(
@@ -787,7 +787,7 @@ class ParallelODCalculator:
         """Solve the OD Cost Matrix in chunks and post-process the results."""
         # Validate OD Cost Matrix settings. Essentially, create a dummy ODCostMatrix class instance and set up the
         # solver object to ensure this at least works. Do this up front before spinning up a bunch of parallel processes
-        # that are guaranteed to all fail. While we're doing this, check and store the field name that  will represent
+        # that are guaranteed to all fail. While we're doing this, check and store the field name that will represent
         # costs in the output OD Lines table. We'll use this in post processing.
         self.optimized_cost_field = self._validate_od_settings()
 

--- a/parallel_route_pairs.py
+++ b/parallel_route_pairs.py
@@ -15,7 +15,7 @@ process, when running within ArcGIS Pro, cannot launch parallel subprocesses on 
 
 This script should not be called directly from the command line.
 
-Copyright 2023 Esri
+Copyright 2024 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/solve_large_odcm.py
+++ b/solve_large_odcm.py
@@ -7,7 +7,7 @@ This is a sample script users can modify to fit their specific needs.
 
 This script can be called from the script tool definition or from the command line.
 
-Copyright 2023 Esri
+Copyright 2024 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/solve_large_route_pair_analysis.py
+++ b/solve_large_route_pair_analysis.py
@@ -11,7 +11,7 @@ This is a sample script users can modify to fit their specific needs.
 
 This script can be called from the script tool definition or from the command line.
 
-Copyright 2023 Esri
+Copyright 2024 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at


### PR DESCRIPTION
Important bug fix.

Destinations are filtered in advance using a simple straight-line distance selection to reduce the number of OD Cost Matrix calculations that need to be performed.  When solving using a time-based travel mode, we convert the time-based cutoff value to distance by assuming a generous travel speed and doing some unit conversions.  However, a variable wasn't initialized properly, and this caused the unit conversion to be skipped.  Consequently, the distance filter was using the travel time value but using it as a distance limit.

When using units like Minutes and either Miles or Kilometers, the values are of the same order of magnitude, so the filter was mostly working, and it wasn't apparent that there was a problem.  However, when a user switched the distance units to Meters and used a 45-minute travel time cutoff, the straight-line selection filtered out all destinations because none were within 45 meters.

The fix is simple: just change the order of something so the travel mode is examined before the straight-line filter is done.